### PR TITLE
Update S3 CommonCrawl URL

### DIFF
--- a/baseline/filter_hunalign_bitext.py
+++ b/baseline/filter_hunalign_bitext.py
@@ -133,4 +133,4 @@ if __name__ == "__main__":
                                % (len(deleted), reason))
             for line in deleted:
                 if line.strip():
-                    args.deleted.write("\t%s\n" % line)
+                    args.deleted.write("\t%s\n" % line.encode('utf-8'))

--- a/metadata/metadata.md
+++ b/metadata/metadata.md
@@ -14,7 +14,7 @@ For recent crawls we use the data files from the common crawl index. These are j
 ```
 mkdir 2015_40
 cd 2015_40
-for i in `seq -w 0 299`; do wget -c https://aws-publicdatasets.s3.amazonaws.com/common-crawl/cc-index/collections/CC-MAIN-2015-40/indexes/cdx-00${i}.gz; done
+for i in `seq -w 0 299`; do wget -c https://commoncrawl.s3.amazonaws.com/cc-index/collections/CC-MAIN-2015-40/indexes/cdx-00${i}.gz; done
 ```
 Restart the above until all files are completed.
 
@@ -65,13 +65,13 @@ Example for May 2015 crawl:
 # Get filelist
 mkdir 2015_22
 cd 2015_22
-wget https://aws-publicdatasets.s3.amazonaws.com/common-crawl/crawl-data/CC-MAIN-2015-22/wet.paths.gz
+wget https://commoncrawl.s3.amazonaws.com/crawl-data/CC-MAIN-2015-22/wet.paths.gz
 
 # Convert to HTTPS URLs
-zcat wet.paths.gz | sed 's/^/https:\/\/aws-publicdatasets.s3.amazonaws.com\//' > $wet.paths.http
+zcat wet.paths.gz | sed 's/^/https:\/\/commoncrawl.s3.amazonaws.com\//' > wet.paths.http
 
 # Make subdirectories
-for f in `zcat wet.paths.gz |  cut -d '/' -f 5 | sort | uniq`; do mkdir -p $f; done;
+for f in $(cat wet.paths.http | cut -d '/' -f 7 | sort | uniq); do mkdir -p $f; done
 
 # Collect monolingual data
 # Set number of jobs to roughly half the number of cores, e.g. -j8 on a 16-core machine.

--- a/metadata/metadatabase.py
+++ b/metadata/metadatabase.py
@@ -104,8 +104,8 @@ def process_cdx(line, args):
     loc, timestamp, data = line.split(' ', 2)
     data = json.loads(data)
     uri = data["url"]
-    # crawl from path, e.g. common-crawl/crawl-data/CC-MAIN-2015-14/
-    crawl = data["filename"].split("/")[2][-7:].replace("-", "_")
+    # crawl from path, e.g. /crawl-data/CC-MAIN-2015-14/
+    crawl = data["filename"].split("/")[1][-7:].replace("-", "_")
     key = make_key(uri, crawl)
 
     filename = commoncrawl_s3_url + data["filename"]
@@ -127,7 +127,7 @@ def read_cdx(args):
             else:  # sometimes several entries are on a single line
                 for entry in re.findall(r"\S+\s\S+\s\{[^}]+\"\}", line):
                     yield process_cdx(entry, args)
-        except ValueError:
+        except (ValueError, KeyError):
             sys.stderr.write("Malformed line: %s\n" % line)
             continue
         except Exception as e:

--- a/metadata/metadatabase.py
+++ b/metadata/metadatabase.py
@@ -7,11 +7,12 @@ from urlparse import urlparse
 import re
 
 magic_number = "df6fa1abb58549287111ba8d776733e9"
+commoncrawl_s3_url = "https://commoncrawl.s3.amazonaws.com/"
 
 
 def make_full_path(crawl, folder, filename):
-    return "https://aws-publicdatasets.s3.amazonaws.com/" +\
-           "common-crawl/crawl-data/" + \
+    return commoncrawl_s3_url +\
+           "crawl-data/" + \
            "CC-MAIN-%s" % crawl.replace("_", "-") +\
            "/segments/%s" % folder +\
            "/warc/%s" % filename.replace("warc.wat.gz", "warc.gz")
@@ -66,8 +67,7 @@ def process_old_json(line, uri, args):
     offset = archive_info['arcFileOffset']
     length = archive_info['compressedSize']
 
-    filename = "https://" + \
-        "aws-publicdatasets.s3.amazonaws.com/" + \
+    filename = commoncrawl_s3_url + \
         "common-crawl/parse-output/segment/" + \
         "%s" % archive_info['arcSourceSegmentId'] + \
         "/%s_%s.arc.gz" % (archive_info['arcFileDate'],
@@ -108,8 +108,7 @@ def process_cdx(line, args):
     crawl = data["filename"].split("/")[2][-7:].replace("-", "_")
     key = make_key(uri, crawl)
 
-    filename = "https://aws-publicdatasets.s3.amazonaws.com/%s" % data[
-        "filename"]
+    filename = commoncrawl_s3_url + data["filename"]
     mime_type = data.get("mime", "UNKNOWN")
     offset = data["offset"]
     length = data["length"]


### PR DESCRIPTION
The base URL of the S3 CommonCrawl bucket changed from "https://aws-publicdatasets.s3.amazonaws.com/common-crawl" to "https://commoncrawl.s3.amazonaws.com". I updated the code and the documentation to reflect these changes.